### PR TITLE
NO-ISSUE: Add .spec.[]osImages.rootFSUrl to example and docs

### DIFF
--- a/docs/hive-integration/kube-api-select-ocp-versions.md
+++ b/docs/hive-integration/kube-api-select-ocp-versions.md
@@ -37,7 +37,8 @@ spec:
   osImages:
     - openshiftVersion: 4.7
       url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso
-      version: 47.83.202102090044-0,
+      rootFSUrl: "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.7/4.7.0/rhcos-live-rootfs.x86_64.img"
+      version: 47.83.202102090044-0
       cpuArchitecture: "x86_64"
 ```
 
@@ -77,7 +78,9 @@ The flow of adding a new version is a follows:
   * ```OSImage``` should include:
     * ```openshiftVersion``` the OCP version in major.minor or major.minor.patch format.
     * ```url``` the RHCOS image (optionally a mirror).
+    * ```rootFSUrl``` the RHCOS rootFS, used when creating minimal-iso configured Discovery ISOs (optionally a mirror).
     * ```version``` the RHOCS version.
+    * ```cpuArchitecture``` the architecture supported by the image and rootFS.
   * Upon starting the service, the relevant host [boot-files](https://github.com/openshift/assisted-service/blob/3823630a0900c7f7a7113d7be4ff5a404a35186b/swagger.yaml#L16) are uploaded to S3/File storage.
 * Deploy a ClusterImageSet with a new ```releaseImage``` URL.
   * The URL can be a mirror to a local registry.


### PR DESCRIPTION
The AgentServiceConfig Custom Resource can specify a RootFS URL for when a minimal-iso configuration is specified for Discovery ISO generation.

This modification is simply an update to include it in the example documentation in the file `docs/hive-integration/kube-api-select-ocp-versions.md`

## List all the issues related to this PR

- [ ] New Feature
- [ ] Enhancement
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

N/A

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
